### PR TITLE
redirect to https

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,14 @@ const feedP = (async () => {
 })();
 
 const app = express();
+app.set('trust proxy', true);
+app.use((req, res, next) => {
+  if (!req.secure && req.hostname !== 'localhost') {
+    res.redirect(`https://${req.hostname}${req.url}`);
+    return;
+  }
+  next();
+});
 app.use(express.static('public'));
 app.get('/videos.xml', async (req, res, next) => {
   try {


### PR DESCRIPTION
I saw a thing on stack overflow that you can construct the https version using `req.hostname`, but that seems to cut out the port. that shouldn't be too much of a problem because we probably don't want to mess with connecting to a local dev instance on a non-standard port. anyway I put in a thing that makes it not redirect when requested as `localhost`.

fixes #1 